### PR TITLE
Now using modern unsafe syntax; Add BufferListTests from Kitura-NIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:4.0.3 SWIFT_SNAPSHOT=4.0.3
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
       env: DOCKER_IMAGE=swift:4.1.3 SWIFT_SNAPSHOT=4.1.3
     - os: linux
       dist: xenial
@@ -30,28 +25,24 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.3-xenial SWIFT_SNAPSHOT=5.0.3
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.0.3 SWIFT_SNAPSHOT=5.0.3
     - os: linux
       dist: xenial
       sudo: required
       services: docker
       # Run Kitura tests in addition to Kitura-net tests
-      env: DOCKER_IMAGE=swift:5.1 CUSTOM_TEST_SCRIPT=.kitura-test.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 CUSTOM_TEST_SCRIPT=.kitura-test.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
     - os: linux
       dist: xenial
       sudo: required
       services: docker
       # Test GCD_ASYNCH codepath on Linux
-      env: DOCKER_IMAGE=swift:5.1 CUSTOM_TEST_SCRIPT=testWithGCD.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 CUSTOM_TEST_SCRIPT=testWithGCD.sh DOCKER_ENVIRONMENT=CUSTOM_TEST_SCRIPT
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
-    - os: osx
-      osx_image: xcode9.2
-      sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci:5.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
     - os: osx
       osx_image: xcode9.4
       sudo: required
@@ -69,6 +60,10 @@ matrix:
       sudo: required
       # Run Kitura tests in addition to Kitura-net tests
       env: CUSTOM_TEST_SCRIPT=.kitura-test.sh
+    - os: osx
+      osx_image: xcode12.2
+      sudo: required
+      env: SWIFT_SNAPSHOT=5.3.1
     - os: osx
       osx_image: xcode11
       sudo: required

--- a/Sources/KituraNet/BufferList.swift
+++ b/Sources/KituraNet/BufferList.swift
@@ -151,8 +151,11 @@ public class BufferList {
      
      */
     public func fill(array: inout [UInt8]) -> Int {
-        
-        return fill(buffer: UnsafeMutablePointer(mutating: array), length: array.count)
+        var filledBytes = 0
+        array.withUnsafeMutableBufferPointer({ bufferPointer in
+            filledBytes = fill(buffer: bufferPointer.baseAddress!, length: bufferPointer.count)
+        })
+        return filledBytes
     }
     
     /**

--- a/Sources/KituraNet/FastCGI/FastCGIRecordParser.swift
+++ b/Sources/KituraNet/FastCGI/FastCGIRecordParser.swift
@@ -88,13 +88,19 @@ class FastCGIRecordParser {
     // which is typically Big to Little.
     //
     private static func getLocalByteOrderSmall(from networkOrderedBytes: [UInt8]) -> UInt16 {
-        let networkOrderedUInt16 = UnsafeRawPointer(networkOrderedBytes).assumingMemoryBound(to: UInt16.self)[0]
-        
-        #if os(Linux)
+
+        let localInt16 = networkOrderedBytes.withUnsafeBytes { pointer -> UInt16 in
+            let uintPointer = pointer.bindMemory(to: UInt16.self)
+            let networkOrderedUInt16 = uintPointer[0]
+            
+            #if os(Linux)
             return Glibc.ntohs(networkOrderedUInt16)
-        #else
+            #else
             return CFSwapInt16BigToHost(networkOrderedUInt16)
-        #endif
+            #endif
+        }
+        
+        return localInt16
     }
     
     //
@@ -102,13 +108,19 @@ class FastCGIRecordParser {
     // which is typically Big to Little.
     //
     private static func getLocalByteOrderLarge(from networkOrderedBytes: [UInt8]) -> UInt32 {
-        let networkOrderedUInt32 = UnsafeRawPointer(networkOrderedBytes).assumingMemoryBound(to: UInt32.self)[0]
-        
-        #if os(Linux)
+
+        let localInt32 = networkOrderedBytes.withUnsafeBytes { pointer -> UInt32 in
+            let uintPointer = pointer.bindMemory(to: UInt32.self)
+            let networkOrderedUInt32 = uintPointer[0]
+            
+            #if os(Linux)
             return Glibc.ntohl(networkOrderedUInt32)
-        #else
+            #else
             return CFSwapInt32BigToHost(networkOrderedUInt32)
-        #endif
+            #endif
+        }
+        
+        return localInt32
     }
     
     // Initialize

--- a/Sources/KituraNet/HTTP/HTTPServerResponse.swift
+++ b/Sources/KituraNet/HTTP/HTTPServerResponse.swift
@@ -264,7 +264,7 @@ public class HTTPServerResponse : ServerResponse {
             processor.write(from: utf8, length: utf8Length)
         }
         else {
-            buffer.append(UnsafePointer(utf8), length: utf8Length)
+            buffer.append(&utf8, length: utf8Length)
         }
     }
     

--- a/Sources/KituraNet/IncomingSocketProcessor.swift
+++ b/Sources/KituraNet/IncomingSocketProcessor.swift
@@ -19,7 +19,7 @@ import Foundation
 /// This protocol defines the API of the classes used to process the data that
 /// comes in from a client's request. There should be one `IncomingSocketProcessor`
 /// instance per incoming request.
-public protocol IncomingSocketProcessor: class {
+public protocol IncomingSocketProcessor: AnyObject {
     
     /// The socket if idle will be kep alive until...
     var keepAliveUntil: TimeInterval { get set }

--- a/Sources/KituraNet/Server/ServerDelegate.swift
+++ b/Sources/KituraNet/Server/ServerDelegate.swift
@@ -16,7 +16,7 @@
 
 /// The protocol defining the delegate for the HTTPServer and the FastCGIServer classes.
 /// The delegate's handle function is invoked when new requests arrive at the server for processing.
-public protocol ServerDelegate: class {
+public protocol ServerDelegate: AnyObject {
     /// Handle new incoming requests to the server
     ///
     /// - Parameter request: The ServerRequest class instance for working with this request.

--- a/Sources/KituraNet/ServerRequest.swift
+++ b/Sources/KituraNet/ServerRequest.swift
@@ -19,7 +19,7 @@ import Foundation
 /// The ServerRequest protocol allows requests to be abstracted 
 /// across different networking protocols in an agnostic way to the
 /// Kitura project Router.
-public protocol ServerRequest: class {
+public protocol ServerRequest: AnyObject {
     
     /// The set of headers received with the incoming request
     var headers : HeadersContainer { get }

--- a/Sources/KituraNet/ServerResponse.swift
+++ b/Sources/KituraNet/ServerResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 /// The ServerResponse protocol allows responses to be abstracted
 /// across different networking protocols in an agnostic way to the
 /// Kitura project Router.
-public protocol ServerResponse: class {
+public protocol ServerResponse: AnyObject {
     
     /// The status code to send in the HTTP response.
     var statusCode: HTTPStatusCode? { get set }

--- a/Tests/KituraNetTests/BufferListTests.swift
+++ b/Tests/KituraNetTests/BufferListTests.swift
@@ -1,0 +1,125 @@
+/*
+ * Copyright IBM Corporation 2016, 2017, 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import KituraNet
+
+class BufferListTests: XCTestCase {
+    var bufferList = BufferList()
+
+    func testAppendUnsafePointerLength() {
+        let array: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        array.withUnsafeBufferPointer { bufferPointer in
+            bufferList.append(bytes: bufferPointer.baseAddress!, length: 10)
+            bufferList.reset()
+        }
+    }
+
+    func testAppendData() {
+        let data = Data(repeating: 0, count: 1024)
+        bufferList.append(data: data)
+        var fillData = Data(capacity: 2048)
+        let result = bufferList.fill(data: &fillData)
+        XCTAssertEqual(result, 1024)
+        bufferList.append(data: data)
+        bufferList.append(data: data)
+        let result0 = bufferList.fill(data: &fillData)
+        XCTAssertEqual(result0, 2048)
+        bufferList.reset()
+    }
+
+    func testFillArray() {
+        let data = Data(repeating: 1, count: 1024)
+        bufferList.append(data: data)
+        var fillArray = [UInt8](repeating: 0, count: 512)
+        let result = bufferList.fill(array: &fillArray)
+        XCTAssertEqual(result, 512)
+        XCTAssertEqual(fillArray.reduce(0) { Int($0) + Int($1) }, 512)
+        var fillArray0 = [UInt8](repeating: 0, count: 1024)
+        let result0 = bufferList.fill(array: &fillArray0)
+        XCTAssertEqual(result0, 512)
+        bufferList.reset()
+    }
+
+    func testFillData() {
+        let data = Data(repeating: 1, count: 512)
+        bufferList.append(data: data)
+        var fillData = Data(capacity: 400)
+        let result = bufferList.fill(data: &fillData)
+        XCTAssertEqual(result, 512)
+        XCTAssertEqual(fillData.reduce(0) { Int($0) + Int($1) }, 512)
+        bufferList.reset()
+    }
+
+    func testFillMutableData() {
+        let data = Data(repeating: 1, count: 512)
+        bufferList.append(data: data)
+        let fillData = NSMutableData(capacity: 400)!
+        let result = bufferList.fill(data: fillData)
+        XCTAssertEqual(result, 512)
+        bufferList.reset()
+    }
+
+    func testFillUnsafeMutablePointer() {
+        let arrayValuesToFill = 64
+        let valueToFill: UInt8 = 3
+        let expectedValue = Int(valueToFill) * arrayValuesToFill
+        
+        let data = Data(repeating: valueToFill, count: 512)
+        bufferList.append(data: data)
+        var array = [UInt8](repeating: 0, count: arrayValuesToFill)
+        array.withUnsafeMutableBufferPointer { bufferPointer in
+            var bytesFilled: Int
+            bytesFilled = bufferList.fill(buffer: bufferPointer.baseAddress!, length: 64)
+            XCTAssertEqual(bytesFilled, 64)
+        }
+        let resolvedValue = array.reduce(0) { Int($0) + Int($1) }
+        XCTAssertEqual(resolvedValue, expectedValue)
+        bufferList.reset()
+    }
+
+    func testRewind() {
+        let data = Data(repeating: 1, count: 64)
+        bufferList.append(data: data)
+        var array0 = [UInt8](repeating: 0, count: 48)
+        let result0 = bufferList.fill(array: &array0)
+        XCTAssertEqual(result0, 48)
+        bufferList.rewind()
+        var array1 = [UInt8](repeating: 0, count: 48)
+        let result1 = bufferList.fill(array: &array1)
+        XCTAssertEqual(result1, 48)
+        bufferList.reset()
+    }
+
+    func testDataAndCount() {
+        let data = Data(repeating: 1, count: 64)
+        bufferList.append(data: data)
+        XCTAssertEqual(bufferList.data.count, 64)
+        XCTAssertEqual(bufferList.count, 64)
+        bufferList.reset()
+    }
+
+    static var allTests = [
+        ("testAppendUnsafePointerLength", testAppendUnsafePointerLength),
+        ("testAppendData", testAppendData),
+        ("testFillArray", testFillArray),
+        ("testFillData", testFillData),
+        ("testFillMutableData", testFillMutableData),
+        ("testFillUnsafeMutablePointer", testFillUnsafeMutablePointer),
+        ("testRewind", testRewind),
+        ("testDataAndCount", testDataAndCount)
+    ]
+}

--- a/Tests/KituraNetTests/FastCGIRequestTests.swift
+++ b/Tests/KituraNetTests/FastCGIRequestTests.swift
@@ -287,33 +287,19 @@ class FastCGIRequestTests: KituraNetTest {
     }
     
     private func copyUInt16IntoBuffer(_ bytes: inout [UInt8], offset: Int, value: UInt16) {
-        var valueNetworkByteOrder: UInt16
-        #if os(Linux)
-            valueNetworkByteOrder = Glibc.htons(value)
-        #else
-            valueNetworkByteOrder = CFSwapInt16HostToBig(value)
-        #endif
-        let asBytes = UnsafeMutablePointer(&valueNetworkByteOrder)
-#if swift(>=4.2)
-        (UnsafeMutableRawPointer(mutating: bytes)+offset).copyMemory(from: asBytes, byteCount: 2)
-#else
-        (UnsafeMutableRawPointer(mutating: bytes)+offset).copyBytes(from: asBytes, count: 2)
-#endif
+        let valueNetworkByteOrder: UInt16 = value.bigEndian
+        
+        bytes[0] = UInt8( (valueNetworkByteOrder >> 8) & 0xff )
+        bytes[1] = UInt8( (valueNetworkByteOrder >> 0) & 0xff )
     }
     
     private func copyUInt32IntoBuffer(_ bytes: inout [UInt8], offset: Int, value: UInt32) {
-        var valueNetworkByteOrder: UInt32
-        #if os(Linux)
-            valueNetworkByteOrder = Glibc.htonl(value)
-        #else
-            valueNetworkByteOrder = CFSwapInt32HostToBig(value)
-        #endif
-        let asBytes = UnsafeMutablePointer(&valueNetworkByteOrder)
-#if swift(>=4.2)
-        (UnsafeMutableRawPointer(mutating: bytes)+offset).copyMemory(from: asBytes, byteCount: 4)
-#else
-        (UnsafeMutableRawPointer(mutating: bytes)+offset).copyBytes(from: asBytes, count: 4)
-#endif
+        let valueNetworkByteOrder: UInt32 = value.bigEndian
+        
+        bytes[0] = UInt8( (valueNetworkByteOrder >> 24) & 0xff )
+        bytes[1] = UInt8( (valueNetworkByteOrder >> 16) & 0xff )
+        bytes[2] = UInt8( (valueNetworkByteOrder >> 8) & 0xff )
+        bytes[3] = UInt8( (valueNetworkByteOrder >> 0) & 0xff )
     }
 
     class TestDelegate : ServerDelegate {

--- a/Tests/KituraNetTests/HTTPResponseTests.swift
+++ b/Tests/KituraNetTests/HTTPResponseTests.swift
@@ -30,7 +30,7 @@ class HTTPResponseTests: KituraNetTest {
         let headers = HeadersContainer()
         
         headers.append("Content-Type", value: "text/html")
-        var values = headers["Content-Type"]
+        let values = headers["Content-Type"]
         XCTAssertNotNil(values, "Couldn't retrieve just set Content-Type header")
         XCTAssertEqual(values?.count, 1, "Content-Type header should only have one value")
         XCTAssertEqual(values?[0], "text/html")

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -43,6 +43,7 @@ extension Sequence {
 }
 
 XCTMain([
+    testCase(BufferListTests.allTests.shuffled()),
     testCase(UnixSocketTests.allTests.shuffled()),
     testCase(ClientE2ETests.allTests.shuffled()),
     testCase(ClientRequestTests.allTests.shuffled()),


### PR DESCRIPTION
- BufferList: update fill() to make better use of bufferPointer
- ClientRequest: update use of unsafeBufferPointer
- FastCGIRecordParser: update with new unsafe syntax
- HTTPServerResponse: update to use new address syntax
- HTTPParser: update to use new unsafe syntax
- IncomingSocketProcessor: conform to AnyObject rather than class
- ServerDelegate: conform to AnyObject rather than class
- ServerRequest: conform to AnyObject rather than class
- ServerResponse: conform to AnyObject rather than class
- BufferListTests: Add tests from Kitura-NIO
- FastCGIRequestTests: Update copyUInt16IntoBuffer() and copyUInt32IntoBuffer() for clarity rather than performance

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
